### PR TITLE
Remove the registred form tags before registring the new ones

### DIFF
--- a/modules/acceptance.php
+++ b/modules/acceptance.php
@@ -11,7 +11,14 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_acceptance' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_acceptance' );
 
 function cf7bs_add_shortcode_acceptance() {
-	wpcf7_add_form_tag( 'acceptance', 'cf7bs_acceptance_shortcode_handler', true );
+    $tags = array( 
+        'acceptance'
+    );
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_acceptance_shortcode_handler', true );
 }
 
 function cf7bs_acceptance_shortcode_handler( $tag ) {

--- a/modules/checkbox.php
+++ b/modules/checkbox.php
@@ -11,11 +11,16 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_checkbox' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_checkbox' );
 
 function cf7bs_add_shortcode_checkbox() {
-	wpcf7_add_form_tag( array(
+    $tags = array(
 		'checkbox',
 		'checkbox*',
 		'radio',
-	), 'cf7bs_checkbox_shortcode_handler', true );
+	);
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_checkbox_shortcode_handler', true );
 }
 
 function cf7bs_checkbox_shortcode_handler( $tag ) {

--- a/modules/count.php
+++ b/modules/count.php
@@ -11,7 +11,14 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_count' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_count' );
 
 function cf7bs_add_shortcode_count() {
-	wpcf7_add_form_tag( 'count', 'cf7bs_count_shortcode_handler', true );
+    $tags = array(
+        'count'
+    );
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_count_shortcode_handler', true );
 }
 
 function cf7bs_count_shortcode_handler( $tag ) {

--- a/modules/date.php
+++ b/modules/date.php
@@ -11,10 +11,15 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_date' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_date' );
 
 function cf7bs_add_shortcode_date() {
-	wpcf7_add_form_tag( array(
+    $tags = array(
 		'date',
 		'date*',
-	), 'cf7bs_date_shortcode_handler', true );
+	);
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_date_shortcode_handler', true );
 }
 
 function cf7bs_date_shortcode_handler( $tag ) {

--- a/modules/file.php
+++ b/modules/file.php
@@ -11,10 +11,15 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_file' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_file' );
 
 function cf7bs_add_shortcode_file() {
-	wpcf7_add_form_tag( array(
+    $tags = array(
 		'file',
 		'file*',
-	), 'cf7bs_file_shortcode_handler', true );
+	);
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_file_shortcode_handler', true );
 }
 
 function cf7bs_file_shortcode_handler( $tag ) {

--- a/modules/number.php
+++ b/modules/number.php
@@ -11,12 +11,17 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_number' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_number' );
 
 function cf7bs_add_shortcode_number() {
-	wpcf7_add_form_tag( array(
+    $tags = array(
 		'number',
 		'number*',
 		'range',
 		'range*',
-	), 'cf7bs_number_shortcode_handler', true );
+	);
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_number_shortcode_handler', true );
 }
 
 function cf7bs_number_shortcode_handler( $tag ) {

--- a/modules/quiz.php
+++ b/modules/quiz.php
@@ -11,7 +11,14 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_quiz' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_quiz' );
 
 function cf7bs_add_shortcode_quiz() {
-	wpcf7_add_form_tag( 'quiz', 'cf7bs_quiz_shortcode_handler', true );
+    $tags = array(
+        'quiz'
+    );
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_quiz_shortcode_handler', true );
 }
 
 function cf7bs_quiz_shortcode_handler( $tag ) {

--- a/modules/really-simple-captcha.php
+++ b/modules/really-simple-captcha.php
@@ -11,10 +11,15 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_captcha' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_captcha' );
 
 function cf7bs_add_shortcode_captcha() {
-	wpcf7_add_form_tag( array(
+    $tags = array(
 		'captchac',
 		'captchar',
-	), 'cf7bs_captcha_shortcode_handler', true );
+	);
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_captcha_shortcode_handler', true );
 }
 
 function cf7bs_captcha_shortcode_handler( $tag ) {

--- a/modules/recaptcha.php
+++ b/modules/recaptcha.php
@@ -15,7 +15,14 @@ if ( function_exists( 'wpcf7_recaptcha_add_shortcode_recaptcha' ) ) {
 		$recaptcha = WPCF7_RECAPTCHA::get_instance();
 
 		if ( $recaptcha->is_active() ) {
-			wpcf7_add_form_tag( 'recaptcha', 'cf7bs_recaptcha_shortcode_handler' );
+            $tags = array(
+                'recaptcha'
+            );
+            foreach ( $tags as $tag ) {
+                wpcf7_remove_form_tag( $tag );
+            }
+            
+			wpcf7_add_form_tag( $tags, 'cf7bs_recaptcha_shortcode_handler' );
 		}
 	}
 

--- a/modules/select.php
+++ b/modules/select.php
@@ -11,10 +11,15 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_select' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_select' );
 
 function cf7bs_add_shortcode_select() {
-	wpcf7_add_form_tag( array(
+    $tags = array(
 		'select',
 		'select*',
-	), 'cf7bs_select_shortcode_handler', true );
+	);
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_select_shortcode_handler', true );
 }
 
 function cf7bs_select_shortcode_handler( $tag ) {

--- a/modules/submit.php
+++ b/modules/submit.php
@@ -11,7 +11,14 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_submit' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_submit' );
 
 function cf7bs_add_shortcode_submit() {
-	wpcf7_add_form_tag( 'submit', 'cf7bs_submit_shortcode_handler' );
+    $tags = array(
+        'submit'
+    );
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_submit_shortcode_handler' );
 }
 
 function cf7bs_submit_shortcode_handler( $tag ) {

--- a/modules/text.php
+++ b/modules/text.php
@@ -11,7 +11,7 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_text' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_text' );
 
 function cf7bs_add_shortcode_text() {
-	wpcf7_add_form_tag( array(
+    $tags = array(
 		'text',
 		'text*',
 		'email',
@@ -20,7 +20,12 @@ function cf7bs_add_shortcode_text() {
 		'url*',
 		'tel',
 		'tel*',
-	), 'cf7bs_text_shortcode_handler', true );
+	);
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_text_shortcode_handler', true );
 }
 
 function cf7bs_text_shortcode_handler( $tag ) {

--- a/modules/textarea.php
+++ b/modules/textarea.php
@@ -11,10 +11,15 @@ remove_action( 'wpcf7_init', 'wpcf7_add_shortcode_textarea' );
 add_action( 'wpcf7_init', 'cf7bs_add_shortcode_textarea' );
 
 function cf7bs_add_shortcode_textarea() {
-	wpcf7_add_form_tag( array(
+    $tags = array(
 		'textarea',
 		'textarea*',
-	), 'cf7bs_textarea_shortcode_handler', true );
+	);
+    foreach ( $tags as $tag ) {
+        wpcf7_remove_form_tag( $tag );
+    }
+    
+	wpcf7_add_form_tag( $tags, 'cf7bs_textarea_shortcode_handler', true );
 }
 
 function cf7bs_textarea_shortcode_handler( $tag ) {


### PR DESCRIPTION
We need to made these changes too because the new method WPCF7_FormTagsManager::add() checks every tag for existing tags. If a tag already exists the method does not overwrite the existing one.